### PR TITLE
1.0.0b6

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,7 +24,7 @@
   - `homebrewItems`
 - Each item is defined as:
   - `"identifier | displayName | validationPath | iconURL"`
-- `validationPath` is operationally important, not cosmetic. It drives pre-execution skip logic and Inspect Mode completion detection.
+- `validationPath` is operationally important, not cosmetic. It drives pre-execution skip logic and Inspect Mode completion detection. For Homebrew items, examples and default validation paths in this repo assume Apple silicon with Homebrew installed in `/opt/homebrew`.
 - The script processes selected items sequentially. There is no parallel execution layer.
 - Homebrew items run in the logged-in user context even though the script itself runs as `root`.
 
@@ -33,7 +33,7 @@
 - Because this repo requires swiftDialog 3.x, the effective minimum supported OS is **macOS 15**.
 - **Installomator** is expected at `/Library/Management/AppAutoPatch/Installomator/Installomator.sh` unless `organizationInstallomatorFile` is changed.
 - **Jamf Pro Binary** is expected at `/usr/local/bin/jamf` unless `jamfBinary` is changed.
-- **Homebrew** is detected at `/opt/homebrew/bin/brew` or `/usr/local/bin/brew` unless `brewPath` is changed.
+- **Homebrew** is detected at `/opt/homebrew/bin/brew` or `/usr/local/bin/brew` unless `brewPath` is changed. Examples and default Homebrew validation paths in this repo assume Apple silicon with Homebrew installed in `/opt/homebrew`.
 - **Network access** may be required for:
   - swiftDialog bootstrap via GitHub API and GitHub release download
   - remote icon assets used in dialogs

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,16 @@
 # SYM-Lite — Agent Instructions
 
-> **Author**: Dan K. Snelson | **Version**: 1.0.0b1 | **Language**: zsh (Shell) | **Platform**: macOS only | **License**: MIT
+> **Author**: Dan K. Snelson | **Version**: 1.0.0b6 | **Language**: zsh (Shell) | **Platform**: macOS only | **License**: MIT
 
 ## Big picture
-- SYM-Lite is a macOS-only, root-run script that unifies Installomator label execution and Jamf Pro policy triggers behind a single swiftDialog-driven workflow.
+- SYM-Lite is a macOS-only, root-run script that unifies Installomator label execution, Jamf Pro policy triggers, and approved Homebrew package installs behind a single swiftDialog-driven workflow.
 - The repo is intentionally small. `SYM-Lite.zsh` contains the runtime logic, UI flow, logging, pre-flight checks, and execution engine. There is no build pipeline or assembled artifact layer in this repo.
 - Default behavior is interactive: show a checkbox selection dialog, launch swiftDialog Inspect Mode, execute selected items sequentially, then show completion and optional restart prompts.
 - Silent behavior is also supported through Jamf-style parameters: Parameter 4 sets `interactive` or `silent`, and Parameter 5 provides a comma-separated item ID list.
-- This project does not manage enrollment, collect device metadata, or orchestrate arbitrary package workflows outside Jamf custom triggers and Installomator labels.
+- This project does not manage enrollment, collect device metadata, or orchestrate arbitrary package workflows outside Jamf custom triggers, Installomator labels, and explicitly configured Homebrew packages.
 
 ## Core components
-1. **`SYM-Lite.zsh`** (CORE) — Single entrypoint and source of truth. Handles logging, pre-flight validation, selection parsing, Inspect Mode JSON generation, Installomator execution, Jamf execution, completion dialogs, and restart flow.
+1. **`SYM-Lite.zsh`** (CORE) — Single entrypoint and source of truth. Handles logging, pre-flight validation, selection parsing, Inspect Mode JSON generation, Installomator execution, Jamf execution, Homebrew execution, completion dialogs, and restart flow.
 2. **`README.md`** (DOCS) — Operator-facing usage and behavior guide. Keep it aligned with user-visible workflow or configuration changes.
 3. **`CHANGELOG.md`** (HISTORY) — Running history of all released versions. This is the canonical long-term change record for the repo.
 4. **`.gitignore`** (HYGIENE) — Minimal macOS and zsh ignore rules. Do not expand it casually.
@@ -18,22 +18,26 @@
 ## Runtime model
 - The script is designed to run as `root`. Logging, temp file creation, Installomator execution, and Jamf execution assume elevated privileges.
 - UI actions require an active logged-in GUI user. Interactive pre-flight waits up to 120 seconds for a valid console user, and `requireLoggedInUser` plus `runAsUser` gate dialog launch and restart confirmation.
-- Item definitions live in two arrays near the top of `SYM-Lite.zsh`:
+- Item definitions live in three arrays near the top of `SYM-Lite.zsh`:
   - `installomatorLabels`
   - `jamfPolicyItems`
+  - `homebrewItems`
 - Each item is defined as:
   - `"identifier | displayName | validationPath | iconURL"`
 - `validationPath` is operationally important, not cosmetic. It drives pre-execution skip logic and Inspect Mode completion detection.
 - The script processes selected items sequentially. There is no parallel execution layer.
+- Homebrew items run in the logged-in user context even though the script itself runs as `root`.
 
 ## Dependencies and external contracts
 - **swiftDialog** is required for all runs because pre-flight always calls `dialogCheck`, and it is auto-installed or updated if missing/outdated. Minimum required version is `3.0.1.4955`.
 - Because this repo requires swiftDialog 3.x, the effective minimum supported OS is **macOS 15**.
 - **Installomator** is expected at `/Library/Management/AppAutoPatch/Installomator/Installomator.sh` unless `organizationInstallomatorFile` is changed.
 - **Jamf Pro Binary** is expected at `/usr/local/bin/jamf` unless `jamfBinary` is changed.
+- **Homebrew** is detected at `/opt/homebrew/bin/brew` or `/usr/local/bin/brew` unless `brewPath` is changed.
 - **Network access** may be required for:
   - swiftDialog bootstrap via GitHub API and GitHub release download
   - remote icon assets used in dialogs
+  - Homebrew metadata/package downloads when Homebrew items are selected
 - Inspect Mode configuration is written to a temp JSON file under `/var/tmp` and handed off to the logged-in GUI user before launch.
 - Logging writes to `/var/log/org.churchofjesuschrist.log` by default, and Installomator progress is read from `/var/log/Installomator.log`.
 
@@ -47,7 +51,7 @@
   - `[WARNING]`
   - `[ERROR]`
   - `[FATAL ERROR]`
-- Installomator and Jamf `stdout` are piped back into the main script log via `logComment`.
+- Installomator, Jamf, and Homebrew `stdout` are piped back into the main script log via `logComment`.
 - When adding or changing workflow branches, prefer:
   - `NOTICE` for phase transitions and important actions
   - `WARNING` for degraded-but-continuable states
@@ -61,7 +65,7 @@
   - `function name() {` declarations
   - braced variable expansion as the default style
   - large hash-wall section separators and generous spacing between top-level blocks
-- Keep `installomatorLabels` and `jamfPolicyItems` sorted by display name intent, because the UI merges and sorts both groups together for presentation.
+- Keep `installomatorLabels`, `jamfPolicyItems`, and `homebrewItems` sorted by display name intent, because the UI merges and sorts all groups together for presentation.
 - If you change user-visible behavior, configuration semantics, or required environment assumptions, update `README.md` in the same pass.
 - `CHANGELOG.md` is the running history for all versions. Add each released version there.
 - The `HISTORY` section in `SYM-Lite.zsh` should only describe changes for the current version under development, not retain the full historical archive.
@@ -70,7 +74,9 @@
 - `dialogInstall()` depends on GitHub API/release availability and Apple package signing validation. Blocked network access breaks automatic swiftDialog bootstrap.
 - Inspect Mode uses the swiftDialog `"preset": "installomator"` log monitor behavior, which is convenient but not something this repo controls.
 - Jamf policies do not have rich progress parsing. They are effectively binary from the UI perspective unless validation paths appear.
+- Homebrew items also do not have rich Inspect Mode parsing. They are path-based from the UI perspective and depend on `brew` being available to a logged-in user.
 - Jamf success with a missing `validationPath` is logged as a warning but still treated as completed.
+- Homebrew success with a missing `validationPath` is logged as a warning and treated as needing review.
 - Skip logic is entirely path-based. A stale file path can suppress needed execution.
 - Interactive flows can fail on headless systems or at the login window; after 120 seconds without a valid GUI user, the script exits. Silent mode is the safer path when no user session is available.
 
@@ -80,7 +86,7 @@
 |----------|-----------|
 | Single-script architecture | Keeps deployment simple and avoids a build/assembly step |
 | Sequential execution | Easier logging, UI tracking, and failure isolation |
-| Unified selection UI for Jamf + Installomator labels | Presents one operator-facing workflow instead of two separate tools |
+| Unified selection UI for Jamf + Installomator + Homebrew items | Presents one operator-facing workflow instead of separate tools |
 | Path-based validation and skip logic | Simple and observable, even if imperfect |
 | Interactive mode owns completion and restart dialogs | Silent mode remains automation-friendly and non-blocking |
 | Auto-install/update swiftDialog | Reduces operator setup friction on managed Macs |
@@ -94,5 +100,5 @@
   1. Pre-flight logs
   2. Item parsing and selection state
   3. Validation paths
-  4. Installomator or Jamf command output relayed into `scriptLog`
+  4. Installomator, Jamf, or Homebrew command output relayed into `scriptLog`
   5. Inspect Mode JSON generation, user handoff, and dialog launch conditions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project are documented in this file.
 
+## 1.0.0b6 - 08-Apr-2026
+- Added approved Homebrew cask/formula items as a third item type in the unified picker and silent-mode CSV flow.
+- Added Homebrew binary detection, configuration toggles, and invalid-item filtering during pre-flight.
+- Added user-context Homebrew execution with optional one-time `brew update` support.
+- Expanded Inspect Mode, completion reporting, and user-facing copy to support Homebrew items alongside Installomator labels and Jamf policies.
+- Updated project documentation and repo instructions for Homebrew item support.
+
 ## 1.0.0b5 - 08-Apr-2026
 - Added pre-flight validation for configured Installomator labels against the active Installomator file.
 - Filtered unavailable Installomator labels out of the interactive picker, silent-mode CSV parsing, and runtime item lookups.

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ homebrewItems=(
 
 **Important:**
 - Use `cask:` or `formula:` prefixes in the item ID
+- Homebrew examples and default validation paths in this repo assume Apple silicon with Homebrew installed in `/opt/homebrew`
 - Homebrew items are hidden for the current run if no working `brew` binary is available
 - Homebrew items also require a valid logged-in user because package installs run in user context rather than as `root`
 
@@ -216,6 +217,7 @@ sudo /path/to/SYM-Lite.zsh "" "" "" silent "microsoftword,cask:docker,formula:no
 - **Homebrew Binary** — Required only when `enableHomebrewItems="true"` and Homebrew items are configured
   - Default detection order: `/opt/homebrew/bin/brew`, then `/usr/local/bin/brew`
   - Set `brewPath` to override detection with an organization-specific path
+  - Homebrew examples and default validation paths in this repo assume Apple silicon with Homebrew installed in `/opt/homebrew`
   - If no working `brew` binary is found, SYM-Lite hides Homebrew items from the current run and warns in the log
   - Homebrew items require a valid logged-in user because package installs run in user context rather than as `root`
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ![GitHub release (latest by date)](https://img.shields.io/github/v/release/Setup-Your-Mac/SYM-Lite?display_name=tag) ![GitHub issues](https://img.shields.io/github/issues-raw/Setup-Your-Mac/SYM-Lite) ![GitHub closed issues](https://img.shields.io/github/issues-closed-raw/Setup-Your-Mac/SYM-Lite) ![GitHub pull requests](https://img.shields.io/github/issues-pr-raw/Setup-Your-Mac/SYM-Lite) ![GitHub closed pull requests](https://img.shields.io/github/issues-pr-closed-raw/Setup-Your-Mac/SYM-Lite)
 
-# SYM-Lite (1.0.0b5)
+# SYM-Lite (1.0.0b6)
 
-> **SYM-Lite** is a lean, purpose-built script for executing MDM-agnostic [Installomator labels](https://github.com/Installomator/Installomator/tree/main/fragments/labels) — and / or Jamf Pro-specific [policy triggers](https://learn.jamf.com/r/en-US/jamf-pro-documentation-current/Triggers_for_Policies) — all through a unified [swiftDialog](https://swiftdialog.app) selection interface
+> **SYM-Lite** is a lean, purpose-built script for executing MDM-agnostic [Installomator labels](https://github.com/Installomator/Installomator/tree/main/fragments/labels), Jamf Pro-specific [policy triggers](https://learn.jamf.com/r/en-US/jamf-pro-documentation-current/Triggers_for_Policies), and approved Homebrew casks/formulas through a unified [swiftDialog](https://swiftdialog.app) selection interface
 
 ## Screenshots
 
@@ -36,13 +36,14 @@
 
 ## Key Features
 
-✓ **Dual execution support** — Installomator labels AND Jamf Pro policies in single session  
+✓ **Unified execution support** — Installomator labels, Jamf Pro policies, and approved Homebrew packages in a single session  
 ✓ **Interactive selection UI** — User-friendly checkbox dialog with per-item icons; optional install-state labels disable already-installed items and exit cleanly when nothing remains selectable  
 ✓ **Alphabetical sorting** — All items sorted together by display name in selection dialog  
 ✓ **Silent mode** — CSV-based automation support  
 ✓ **Early Installomator label validation** — Configured Installomator labels are verified against the active Installomator file before they can appear or run  
-✓ **Inspect Mode monitoring** — Real-time progress with rich status updates for Installomator labels  
-✓ **Log monitoring** — Parses Installomator.log for intermediate states (downloading, installing, verifying)  
+✓ **Homebrew package support** — Approved casks and formulas run in the logged-in user context when `brew` is available  
+✓ **Inspect Mode monitoring** — Rich status updates for Installomator labels and path-based progress for Jamf/Homebrew items  
+✓ **Log monitoring** — Parses Installomator.log for intermediate states and captures Homebrew/Jamf output into the main log  
 ✓ **Path-based validation** — Pre/post-execution checks via file system monitoring  
 ✓ **Cache monitoring** — Detects in-progress downloads  
 ✓ **Completion report** — Per-item results summary and optional restart prompt  
@@ -96,6 +97,31 @@ jamfPolicyItems=(
 - Full URL: `https://...`
 - SF Symbol: `SF=symbolname,weight=semibold,colour1=auto,colour2=auto`
 
+### Adding Homebrew Items
+
+Edit the `homebrewItems` array near the top of `SYM-Lite.zsh`:
+
+```zsh
+homebrewItems=(
+    "cask:token | Display Name | Validation Path | Icon URL"
+    "formula:token | Display Name | Validation Path | Icon URL"
+)
+```
+
+**Example:**
+```zsh
+homebrewItems=(
+    "cask:docker | Docker Desktop | /Applications/Docker.app | https://icon.url"
+    "formula:node | Node.js | /opt/homebrew/bin/node | SF=terminal"
+    "formula:python@3.12 | Python 3.12 | /opt/homebrew/bin/python3.12 | SF=terminal"
+)
+```
+
+**Important:**
+- Use `cask:` or `formula:` prefixes in the item ID
+- Homebrew items are hidden for the current run if no working `brew` binary is available
+- Homebrew items also require a valid logged-in user because package installs run in user context rather than as `root`
+
 ### Disabling Jamf Policy Items
 
 If your environment does not use Jamf Pro, set `enableJamfPolicyItems="false"` near the top of `SYM-Lite.zsh`.
@@ -105,6 +131,16 @@ When Jamf policy items are disabled:
 - Jamf policy items do not execute
 - Jamf binary pre-flight validation is skipped
 - Silent mode warns and skips Jamf item IDs in the CSV input
+
+### Disabling Homebrew Items
+
+If your environment does not use Homebrew packages through SYM-Lite, set `enableHomebrewItems="false"` near the top of `SYM-Lite.zsh`.
+
+When Homebrew items are disabled:
+- Homebrew items do not appear in the interactive selection UI
+- Homebrew items do not execute
+- Homebrew pre-flight detection is skipped
+- Silent mode warns and skips Homebrew item IDs in the CSV input
 
 ---
 
@@ -138,11 +174,11 @@ Run with Jamf parameters or direct positional arguments:
 
 **Via Jamf Policy:**
 - Parameter 4: `silent`
-- Parameter 5: `microsoftword,googlechrome,installRosetta`
+- Parameter 5: `microsoftword,cask:docker,formula:node,installRosetta`
 
 **Direct execution:**
 ```bash
-sudo /path/to/SYM-Lite.zsh "" "" "" silent "microsoftword,googlechrome"
+sudo /path/to/SYM-Lite.zsh "" "" "" silent "microsoftword,cask:docker,formula:node"
 ```
 
 **Silent mode behavior:**
@@ -153,6 +189,7 @@ sudo /path/to/SYM-Lite.zsh "" "" "" silent "microsoftword,googlechrome"
 - Same pre-flight checks still run, including `swiftDialog` validation / installation
 - Installomator labels filtered out during pre-flight validation are warned and skipped in the CSV input
 - If Jamf policy items are disabled, Jamf item IDs in the CSV are warned and skipped
+- If Homebrew items are disabled or unavailable for the current run, Homebrew item IDs in the CSV are warned and skipped
 - Exits with an error if the CSV contains no valid item IDs
 - Suitable for automated deployment
 
@@ -176,6 +213,11 @@ sudo /path/to/SYM-Lite.zsh "" "" "" silent "microsoftword,googlechrome"
 - **Jamf Pro Binary** — Required only when `enableJamfPolicyItems="true"` and Jamf policy items are configured
   - Default path: `/usr/local/bin/jamf`
   - If the binary is missing, pre-flight logs warnings and selected Jamf policy items will fail at execution time
+- **Homebrew Binary** — Required only when `enableHomebrewItems="true"` and Homebrew items are configured
+  - Default detection order: `/opt/homebrew/bin/brew`, then `/usr/local/bin/brew`
+  - Set `brewPath` to override detection with an organization-specific path
+  - If no working `brew` binary is found, SYM-Lite hides Homebrew items from the current run and warns in the log
+  - Homebrew items require a valid logged-in user because package installs run in user context rather than as `root`
 
 ---
 
@@ -186,6 +228,7 @@ PRE-FLIGHT CHECKS
   ├─ Verify root
   ├─ Check/install swiftDialog
   ├─ Normalize Jamf item availability from configuration
+  ├─ Normalize Homebrew item availability and detect brew path
   ├─ Validate Installomator file and normalize Installomator labels
   └─ Verify Jamf binary (if enabled and items configured)
        ↓
@@ -197,7 +240,7 @@ SELECTION INTERFACE
 INSPECT MODE CONFIGURATION
   ├─ Interactive mode only
   ├─ Build unified JSON config
-  ├─ Merge Installomator + Jamf items
+  ├─ Merge Installomator + Jamf + Homebrew items
   ├─ Add cachePaths for download detection
   └─ Validate JSON with plutil
        ↓
@@ -206,7 +249,8 @@ EXECUTION ENGINE
   │   └─ Silent mode logs progress without UI
   ├─ Process items sequentially
   │   ├─ Installomator: executeInstallomatorLabel()
-  │   └─ Jamf: executeJamfPolicy()
+  │   ├─ Jamf: executeJamfPolicy()
+  │   └─ Homebrew: executeHomebrewItem()
   ├─ Interactive mode waits for Inspect Mode to close
   └─ Silent mode exits when execution completes
        ↓
@@ -245,9 +289,17 @@ swiftDialog's [Inspect Mode](https://swiftdialog.app/advanced/inspect-mode/) use
   - "Waiting" (policy executing)
   - "Completed" (validation path detected)
 
+### For Homebrew Items (Binary Status)
+
+**File System Monitoring Only:**
+- No Inspect Mode log parsing (Homebrew items rely on validation paths)
+- Shows binary states:
+  - "Waiting" (package install executing)
+  - "Completed" (validation path detected)
+
 ### Common Features
 
-**Both types benefit from:**
+**All item types benefit from:**
 - `cachePaths` monitoring — Detects `.pkg`, `.dmg`, `.download` files in progress
 - `scanInterval: 2` — Checks for path changes every 2 seconds
 - Auto-enable Close button when all items complete
@@ -264,6 +316,11 @@ swiftDialog's [Inspect Mode](https://swiftdialog.app/advanced/inspect-mode/) use
 2. Dialog shows: "Waiting" → No intermediate updates
 3. Path appears: `/usr/bin/arch` → Marks complete
 
+**Example Flow (Homebrew Formula):**
+1. Script executes Homebrew as the logged-in user: `brew install node`
+2. Dialog shows: "Waiting" while the package installs
+3. Path appears: `/opt/homebrew/bin/node` → Marks complete
+
 ---
 
 ## Restart Prompt Behavior
@@ -272,7 +329,7 @@ In interactive mode, after all items complete and the completion report closes, 
 
 **Restart Prompt Dialog:**
 - Title: "Restart Recommended"
-- Message: "A restart is recommended after performing any installation. Would you like to restart now?"
+- Message: "A restart may be recommended after installing software or applying these changes. Would you like to restart now?"
 - Button 1: "Restart Now"
 - Button 2: "Later"
 
@@ -324,6 +381,15 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
    - Exit code 0 + validation path missing = success (warn)
    - Non-zero exit code = failure
 
+### Homebrew Items
+1. **Pre-check:** If validation path exists → skip, log "already exists"
+2. **Execute:** Run Homebrew as the logged-in user with `brew install` or `brew install --cask`
+3. **Inspect Mode:** Watches validation path, marks complete when the path appears
+4. **Post-check:**
+   - Exit code 0 + validation path exists = success
+   - Exit code 0 + validation path missing = success (needs review)
+   - Non-zero exit code = failure
+
 **Important:** Inspect Mode visual feedback is independent of script success/failure tracking. The dialog shows items as complete when paths appear, but the script tracks actual execution success separately.
 
 ---
@@ -337,6 +403,9 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 | `installomatorLog` | `/var/log/Installomator.log` | Installomator log path for monitoring |
 | `jamfBinary` | `/usr/local/bin/jamf` | Path to jamf binary |
 | `enableJamfPolicyItems` | `"true"` | Show and execute Jamf policy items |
+| `brewPath` | `""` | Optional Homebrew binary override |
+| `enableHomebrewItems` | `"true"` | Show and execute Homebrew cask/formula items |
+| `homebrewUpdateBeforeInstall` | `"false"` | Run `brew update` once before the first Homebrew package install |
 | `organizationOverlayiconURL` | swiftDialog logo | Overlay icon URL |
 | `mainDialogIcon` | GitHub raw `SYM_icon.png` URL | Main dialog icon |
 | `fontSize` | `"14"` | Dialog message font size |
@@ -362,11 +431,13 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 **Output Capture:**
 - Installomator output: Captured and logged with `Installomator (label):` prefix
 - Jamf policy output: Captured and logged with `Jamf (trigger):` prefix
+- Homebrew output: Captured and logged with `Homebrew (itemID):` prefix
 - All output written to primary script log for troubleshooting
 
 **Inspect Mode Monitoring:**
 - **Installomator labels:** Log parsing (`/var/log/Installomator.log`) + file system monitoring
 - **Jamf policies:** File system monitoring only (FSEvents)
+- **Homebrew items:** File system monitoring only (FSEvents)
 - Items mark complete when validation paths appear
 - Rich status updates shown for Installomator labels during execution
 
@@ -397,11 +468,20 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 - Test label manually: `sudo /path/to/Installomator.sh <label> DEBUG=1`
 - Check label exists and is spelled correctly
 
+### Homebrew failures
+- Verify brew path: `ls -l /opt/homebrew/bin/brew /usr/local/bin/brew`
+- If you set `brewPath`, confirm the override is executable
+- Verify a real user is logged in at the macOS desktop; Homebrew items run in user context
+- Test manually as the logged-in user: `brew install <formula>` or `brew install --cask <cask>`
+- Review validation paths carefully; Homebrew success still depends on the configured path appearing
+
 ### Missing dependencies
 - If `swiftDialog` is unavailable and cannot be installed, the script exits during pre-flight
 - If `Installomator.sh` is missing, pre-flight logs warnings but selected Installomator labels fail when executed
 - If the `jamf` binary is missing, pre-flight logs warnings but selected Jamf policy items fail when executed
+- If the `brew` binary is missing or no logged-in user is available, configured Homebrew items are hidden for the current run
 - If `enableJamfPolicyItems="false"`, Jamf policy items are hidden and the `jamf` binary is not required
+- If `enableHomebrewItems="false"`, Homebrew items are hidden and `brew` is not required
 
 ### Interactive mode exits before showing dialogs
 - Verify a real user is logged in at the macOS desktop
@@ -412,6 +492,7 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 - Verify items are configured in arrays
 - Check array syntax (space-padded pipe-separated fields: `"id | Display Name | /validation/path | iconURL"`)
 - Review pre-flight log for parsing errors
+- Homebrew items are hidden automatically if `brew` is unavailable or no logged-in user can run them
 
 ### Script hangs after clicking Close
 - Script implements 30-second timeout for dialog close
@@ -427,12 +508,14 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 ### Before Production
 - [ ] Edit `installomatorLabels` array with organization's apps
 - [ ] Edit `jamfPolicyItems` array with organization's policies, or disable Jamf policy items if unused
+- [ ] Edit `homebrewItems` array with approved casks and formulas, or disable Homebrew items if unused
 - [ ] Update icon URLs to organization's icons
 - [ ] Verify Installomator path matches environment
 - [ ] Verify Jamf binary path matches environment if Jamf policy items are enabled
+- [ ] Verify Homebrew path detection or `brewPath` override if Homebrew items are enabled
 - [ ] Test interactive mode with single item
 - [ ] Test silent mode with CSV input
-- [ ] Test mixed selection (Installomator + Jamf)
+- [ ] Test mixed selection (Installomator + Jamf + Homebrew)
 - [ ] Verify validation paths are correct
 - [ ] Test failure handling (invalid label/trigger)
 - [ ] Test skip logic (pre-installed items)
@@ -442,18 +525,19 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 1. **Interactive single item:** Select one Installomator label → verify install
 2. **Interactive multiple:** Select 2+ items → verify sequential execution
 3. **Silent mode:** Run with CSV → verify no dialogs, auto-execute
-4. **Mixed execution:** Select both types → verify both execute correctly
+4. **Mixed execution:** Select all configured item types → verify each executes correctly
 5. **Skip logic:** Select already-installed item → verify skip
-6. **Failure handling:** Select invalid item → verify error capture
-7. **Completion dialog:** Verify success/failure counts accurate
-8. **Restart prompt:** Test both "Restart Now" and "Later" buttons
+6. **Homebrew formula:** Select one formula item → verify user-context install and validation
+7. **Failure handling:** Select invalid item → verify error capture
+8. **Completion dialog:** Verify success/failure counts accurate
+9. **Restart prompt:** Test both "Restart Now" and "Later" buttons
 
 ---
 
 ## Next Steps
 
-1. **Configure items** — Edit arrays with your organization's apps and policies
-2. **Update paths** — Verify Installomator and Jamf paths match your environment
+1. **Configure items** — Edit arrays with your organization's apps, policies, and approved Homebrew packages
+2. **Update paths** — Verify Installomator, Jamf, and Homebrew paths match your environment
 3. **Icon URLs** — Replace example URLs with your organization's icon URLs
 4. **Test in VM** — Run through test checklist in non-production environment
 5. **Deploy to Self Service** — Add as Jamf Self Service policy with appropriate scope
@@ -471,9 +555,10 @@ Set `restartPromptEnabled="false"` in the script to skip the prompt entirely in 
 - Validate swiftDialog: `/usr/local/bin/dialog --version`
 - Test Installomator: `sudo /path/to/Installomator.sh <label> DEBUG=1`
 - Test Jamf trigger: `sudo jamf policy -event <trigger> -verbose`
+- Test Homebrew item as the logged-in user: `brew install <formula>` or `brew install --cask <cask>`
 
 ---
 
-**Version:** 1.0.0b4  
+**Version:** 1.0.0b6  
 **Date:** 08-Apr-2026  
 **Author:** Dan K. Snelson (@dan-snelson)

--- a/SYM-Lite.zsh
+++ b/SYM-Lite.zsh
@@ -1727,7 +1727,7 @@ function showSelectionDialog() {
     local rc
 
     # Build message
-    baseMessage="**$(date +'Happy %A,') ${loggedInUserFirstname}!**\n\nSelect one or more approved items to process."
+    baseMessage="**$(date +'Happy %A,') ${loggedInUserFirstname}!**\n\nSelect items to install; Homebrew casks and formulae are available **after** \`brew\` has been installed."
 
     # Build unified checkbox list (Installomator + Jamf, sorted together by display name)
     getSelectionDialogCheckboxesJSON

--- a/SYM-Lite.zsh
+++ b/SYM-Lite.zsh
@@ -5,7 +5,7 @@
 #
 # SYM-Lite
 #
-# - Lean, purpose-built script for executing Jamf Pro Policy Custom Triggers and Installomator labels
+# - Lean, purpose-built script for executing approved software and management actions
 # - User selects which items to install/execute via swiftDialog selection UI
 # - Monitors execution progress via swiftDialog Inspect Mode
 # - No user input prompts beyond selection (no asset tag, computer name, etc.)
@@ -16,12 +16,12 @@
 #
 # HISTORY
 #
-# Version 1.0.0b5, 08-Apr-2026, Dan K. Snelson (@dan-snelson)
-# - Added pre-flight validation for configured Installomator labels against the active Installomator file.
-# - Filtered unavailable Installomator labels out of the interactive picker, silent-mode CSV parsing, and runtime lookups.
-# - Updated the no-selectable-items dialog so filtered labels do not appear as already installed.
-# - Refined Installomator dependency handling to fail fast when the configured file is unusable.
-# - Updated release documentation for early Installomator label validation.
+# Version 1.0.0b6, 08-Apr-2026, Dan K. Snelson (@dan-snelson)
+# - Added approved Homebrew cask/formula items as a third item type in the unified picker and silent-mode CSV flow.
+# - Added Homebrew binary detection, configuration toggles, and invalid-item filtering during pre-flight.
+# - Executed Homebrew package installs in the logged-in user context while preserving root-run script behavior.
+# - Expanded Inspect Mode, completion reporting, and user-facing copy to support software items beyond Installomator labels.
+# - Updated release documentation for Homebrew item support.
 #
 ####################################################################################################
 
@@ -38,7 +38,7 @@ setopt NONOMATCH
 setopt TYPESET_SILENT
 
 # Script Version
-scriptVersion="1.0.0b5"
+scriptVersion="1.0.0b6"
 
 # Script Human-readable Name
 humanReadableScriptName="Setup Your Mac Lite: Developer Edition"
@@ -86,8 +86,17 @@ organizationInstallomatorFile="/Library/Management/AppAutoPatch/Installomator/In
 # Organization's Jamf Binary Path
 jamfBinary="/usr/local/bin/jamf"
 
+# Optional Homebrew binary override (otherwise /opt/homebrew/bin/brew, then /usr/local/bin/brew)
+brewPath=""
+
 # Enable or disable Jamf policy items
 enableJamfPolicyItems="true"
+
+# Enable or disable Homebrew package items
+enableHomebrewItems="true"
+
+# Update Homebrew metadata once before the first Homebrew package install
+homebrewUpdateBeforeInstall="false"
 
 # Organization's Overlayicon URL
 organizationOverlayiconURL="https://swiftdialog.app/_astro/dialog_logo.CZF0LABZ_ZjWz8w.webp"
@@ -115,6 +124,7 @@ installomatorLabels=(
     "awsvpnclient | AWS VPN Client | /Applications/AWS VPN Client/AWS VPN Client.app | https://usw2.ics.services.jamfcloud.com/icon/hash_1d1bef5523d9f7eca5a45f2db9a63732e85edb5f914220807ca740ba7c4881b9"
     "bruno | Bruno | /Applications/Bruno.app | https://usw2.ics.services.jamfcloud.com/icon/hash_48501630ad2f5dd5de3e055d6acdda07682895440cad366ee7befac71cab1399"
     "charles | Charles Proxy | /Applications/Charles.app | https://use2.ics.services.jamfcloud.com/icon/hash_59b395ca81889a6d83deda8e6babc5ae4bc5931d36a72b738fe30b84d027593d"
+    "codex | Codex | /Applications/Codex.app | https://usw2.ics.services.jamfcloud.com/icon/hash_9d2a1b6f204d2a0d6e99dfc7a411edc0d269c1ab748514dcdde46ea7b4277e51"
     "docker | Docker | /Applications/Docker.app | https://usw2.ics.services.jamfcloud.com/icon/hash_a344dca5fdc0e86822e8f21ec91088e6591b1e292bdcebdee1281fbd794c2724"
     "jetbrainsintellijidea | IntelliJ IDEA | /Applications/IntelliJ IDEA.app | https://usw2.ics.services.jamfcloud.com/icon/hash_f669d73acc06297e1fc2f65245cfbdace03263f81aebf95444a8360a101b239d"
     "pique | Pique | /Applications/Pique.app | https://usw2.ics.services.jamfcloud.com/icon/hash_7d2539860cca6ec5ea5a71cba2aee7d93b9534e4267c16f73c7035f3dc025b9c"
@@ -131,6 +141,16 @@ jamfPolicyItems=(
 )
 
 configuredJamfPolicyItems=("${jamfPolicyItems[@]}")
+
+# Homebrew Items
+# Format: "cask:token | Display Name | Validation Path | Icon URL"
+homebrewItems=(
+    "cask:1password-cli | 1Password CLI | /opt/homebrew/bin/op | https://usw2.ics.services.jamfcloud.com/icon/hash_9456dcae0b68fa522a7b411e7ebd2f9062a1a60cb0681ab3cbad3dda64a410c6"
+    "cask:codex | codex-cli | /opt/homebrew/bin/codex | https://usw2.ics.services.jamfcloud.com/icon/hash_9d2a1b6f204d2a0d6e99dfc7a411edc0d269c1ab748514dcdde46ea7b4277e51"
+    "formula:direnv | direnv | /opt/homebrew/bin/direnv | https://usw2.ics.services.jamfcloud.com/icon/hash_a9a7557b3142dd165372a1e66bca2533c783723956f1415861eac6fd5058b588"
+)
+
+configuredHomebrewItems=("${homebrewItems[@]}")
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
@@ -155,6 +175,7 @@ dialogInspectModeJSONFile=""
 selectedItems=()
 selectedInstallomatorLabels=()
 selectedJamfPolicies=()
+selectedHomebrewItems=()
 failedItems=()
 completedItems=()
 skippedItems=()
@@ -166,6 +187,9 @@ selectionDialogOptionRecords=()
 selectionDialogTotalItemCount=0
 selectionDialogDisabledItemCount=0
 selectionDialogCheckboxesJSON=""
+effectiveBrewPath=""
+homebrewUpdateAttempted="false"
+homebrewUpdateSucceeded="false"
 
 
 
@@ -315,6 +339,26 @@ function parseJamfPolicyItem() {
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Parse Homebrew Item Configuration
+# Input: "cask:token | displayName | validationPath | iconURL"
+# Output: Sets global variables itemHomebrewID, itemBrewMode, itemBrewToken, itemDisplayName, itemValidationPath, itemIconURL
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function parseHomebrewItem() {
+    local itemConfig="$1"
+    local parts=("${(@s: | :)itemConfig}")
+
+    itemHomebrewID="${parts[1]}"
+    itemBrewMode="${itemHomebrewID%%:*}"
+    itemBrewToken="${itemHomebrewID#*:}"
+    itemDisplayName="${parts[2]}"
+    itemValidationPath="${parts[3]}"
+    itemIconURL="${parts[4]}"
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Get Selection Dialog Status Text
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -374,6 +418,10 @@ function getSelectionDialogCheckboxesJSON() {
         local parts=("${(@s: | :)item}")
         allSortKeys+=("${parts[2]} | jamf | ${item}")
     done
+    for item in "${homebrewItems[@]}"; do
+        local parts=("${(@s: | :)item}")
+        allSortKeys+=("${parts[2]} | homebrew | ${item}")
+    done
 
     for entry in "${(oi)allSortKeys[@]}"; do
         ((selectionDialogTotalItemCount++))
@@ -384,9 +432,12 @@ function getSelectionDialogCheckboxesJSON() {
         if [[ "${itemType}" == "installomator" ]]; then
             parseInstallomatorItem "${itemConfig}"
             itemID="${itemLabel}"
-        else
+        elif [[ "${itemType}" == "jamf" ]]; then
             parseJamfPolicyItem "${itemConfig}"
             itemID="${itemTrigger}"
+        else
+            parseHomebrewItem "${itemConfig}"
+            itemID="${itemHomebrewID}"
         fi
 
         checkboxLabel=$(getSelectionDialogLabel "${itemDisplayName}" "${itemValidationPath}")
@@ -583,6 +634,158 @@ function normalizeJamfPolicyItems() {
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Refresh Homebrew Execution User
+# Returns: 0 if a resolvable logged-in user is available, 1 otherwise
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function refreshHomebrewExecutionUser() {
+    currentLoggedInUser "false"
+
+    if [[ -z "${loggedInUser}" || "${loggedInUser}" == "loginwindow" ]]; then
+        return 1
+    fi
+
+    if ! /usr/bin/id -u "${loggedInUser}" >/dev/null 2>&1; then
+        return 1
+    fi
+
+    updateLoggedInUserDetails
+    return 0
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Detect Effective Homebrew Binary
+# Returns: Path to Homebrew binary on stdout, or empty if unavailable
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function detectHomebrewBinary() {
+    if [[ -n "${brewPath}" ]]; then
+        if [[ -x "${brewPath}" ]]; then
+            print -r -- "${brewPath}"
+        fi
+        return 0
+    fi
+
+    if [[ -x "/opt/homebrew/bin/brew" ]]; then
+        print -r -- "/opt/homebrew/bin/brew"
+        return 0
+    fi
+
+    if [[ -x "/usr/local/bin/brew" ]]; then
+        print -r -- "/usr/local/bin/brew"
+        return 0
+    fi
+
+    print -r -- ""
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Normalize Homebrew Item Availability
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function normalizeHomebrewItems() {
+    local homebrewItemsSetting="${enableHomebrewItems:l}"
+    local detectedBrewPath=""
+    local filteredItemCount=0
+    local item=""
+    local -a normalizedHomebrewItems=()
+
+    if [[ "${homebrewItemsSetting}" != "true" && "${homebrewItemsSetting}" != "false" ]]; then
+        warning "Invalid enableHomebrewItems value '${enableHomebrewItems}'; defaulting to true"
+        enableHomebrewItems="true"
+        homebrewItemsSetting="true"
+    fi
+
+    if [[ "${homebrewItemsSetting}" != "true" ]]; then
+        homebrewItems=()
+        effectiveBrewPath=""
+        return 0
+    fi
+
+    homebrewItems=("${configuredHomebrewItems[@]}")
+
+    if [[ ${#homebrewItems[@]} -eq 0 ]]; then
+        preFlight "No Homebrew items configured"
+        effectiveBrewPath=""
+        return 0
+    fi
+
+    detectedBrewPath="$(detectHomebrewBinary)"
+    if [[ -z "${detectedBrewPath}" ]]; then
+        if [[ -n "${brewPath}" ]]; then
+            warning "Configured Homebrew path is unavailable or not executable: ${brewPath}"
+        else
+            warning "Homebrew binary not found at /opt/homebrew/bin/brew or /usr/local/bin/brew"
+        fi
+        warning "Homebrew items will be hidden from this run until Homebrew is installed"
+        homebrewItems=()
+        effectiveBrewPath=""
+        return 0
+    fi
+
+    effectiveBrewPath="${detectedBrewPath}"
+    preFlight "Homebrew binary found at ${effectiveBrewPath}"
+
+    if ! refreshHomebrewExecutionUser; then
+        warning "No logged-in user is available to run Homebrew; hiding Homebrew items from this run"
+        homebrewItems=()
+        effectiveBrewPath=""
+        return 0
+    fi
+
+    preFlight "Homebrew items will run as ${loggedInUser}"
+
+    for item in "${configuredHomebrewItems[@]}"; do
+        parseHomebrewItem "${item}"
+
+        if [[ "${itemBrewMode}" != "cask" && "${itemBrewMode}" != "formula" ]]; then
+            errorOut "Configured Homebrew item '${itemHomebrewID}' (${itemDisplayName}) has an invalid prefix; use 'cask:' or 'formula:'"
+            ((filteredItemCount++))
+            continue
+        fi
+
+        if [[ -z "${itemBrewToken}" || "${itemBrewToken}" == "${itemHomebrewID}" ]]; then
+            errorOut "Configured Homebrew item '${itemHomebrewID}' (${itemDisplayName}) is missing a package token; hiding it from this run"
+            ((filteredItemCount++))
+            continue
+        fi
+
+        normalizedHomebrewItems+=("${item}")
+    done
+
+    homebrewItems=("${normalizedHomebrewItems[@]}")
+    preFlight "Homebrew item validation complete: ${#homebrewItems[@]} available, ${filteredItemCount} filtered"
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Check Configured Homebrew Item
+# Input: Item ID
+# Output: 0 if item exists in configuredHomebrewItems, 1 otherwise
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function isConfiguredHomebrewItem() {
+    local itemID="$1"
+    local item
+
+    for item in "${configuredHomebrewItems[@]}"; do
+        local parts=("${(@s: | :)item}")
+        if [[ "${parts[1]}" == "${itemID}" ]]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Check Configured Jamf Policy Item
 # Input: Item ID
 # Output: 0 if item exists in configuredJamfPolicyItems, 1 otherwise
@@ -645,6 +848,12 @@ function getAllItemIDs() {
         local parts=("${(@s: | :)item}")
         allIDs+=("${parts[1]}")
     done
+
+    # Add Homebrew item IDs
+    for item in "${homebrewItems[@]}"; do
+        local parts=("${(@s: | :)item}")
+        allIDs+=("${parts[1]}")
+    done
     
     print -r -- "${allIDs[@]}"
 }
@@ -674,6 +883,15 @@ function getItemType() {
         local parts=("${(@s: | :)item}")
         if [[ "${parts[1]}" == "${itemID}" ]]; then
             print -r -- "jamf"
+            return 0
+        fi
+    done
+
+    # Check Homebrew items
+    for item in "${homebrewItems[@]}"; do
+        local parts=("${(@s: | :)item}")
+        if [[ "${parts[1]}" == "${itemID}" ]]; then
+            print -r -- "homebrew"
             return 0
         fi
     done
@@ -710,6 +928,15 @@ function getItemConfig() {
             return 0
         fi
     done
+
+    # Check Homebrew items
+    for item in "${homebrewItems[@]}"; do
+        local parts=("${(@s: | :)item}")
+        if [[ "${parts[1]}" == "${itemID}" ]]; then
+            print -r -- "${item}"
+            return 0
+        fi
+    done
     
     print -r -- ""
     return 1
@@ -731,6 +958,28 @@ function escapeJSONString() {
     value="${value//$'\t'/\\t}"
 
     print -r -- "${value}"
+}
+
+function buildJSONStringArray() {
+    local value=""
+    local jsonOutput=""
+    local separator=""
+
+    for value in "$@"; do
+        [[ -z "${value}" ]] && continue
+        jsonOutput="${jsonOutput}${separator}        \"$(escapeJSONString "${value}")\""
+        separator=$',\n'
+    done
+
+    print -r -- "${jsonOutput}"
+}
+
+function getHomebrewCacheDirectory() {
+    if [[ -n "${loggedInUserHomeDirectory}" ]]; then
+        print -r -- "${loggedInUserHomeDirectory}/Library/Caches/Homebrew"
+    else
+        print -r -- ""
+    fi
 }
 
 function isValidationPathPresent() {
@@ -1050,6 +1299,20 @@ fi
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Pre-flight Check: Normalize Homebrew Item Availability
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+normalizeHomebrewItems
+
+if [[ "${enableHomebrewItems:l}" == "true" ]]; then
+    preFlight "Homebrew items enabled (${#homebrewItems[@]} configured for this run)"
+else
+    preFlight "Homebrew items disabled by configuration"
+fi
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Pre-flight Check: Validate Installomator Labels
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -1096,6 +1359,12 @@ function createSYMLiteInspectConfig() {
     local messageText
     local cachePathsJSON
     local sideMessageJSON
+    local logMonitorJSON=""
+    local -a cachePaths=()
+    local -a sideMessages=()
+    local hasInstallomator="false"
+    local hasJamf="false"
+    local hasHomebrew="false"
 
     dialogInspectModeJSONFile=$( /usr/bin/mktemp "/var/tmp/dialogJSONFile_InspectMode_${organizationScriptName}.XXXXXX" )
     if [[ -z "${dialogInspectModeJSONFile}" || ! -e "${dialogInspectModeJSONFile}" ]]; then
@@ -1117,20 +1386,29 @@ function createSYMLiteInspectConfig() {
         if [[ "${itemType}" == "installomator" ]]; then
             parseInstallomatorItem "${itemConfig}"
             local jsonBlock="{
-            \"id\": \"${itemLabel}\",
-            \"displayName\": \"${itemDisplayName}\",
+            \"id\": \"$(escapeJSONString "${itemLabel}")\",
+            \"displayName\": \"$(escapeJSONString "${itemDisplayName}")\",
             \"guiIndex\": ${guiIndex},
-            \"paths\": [\"${itemValidationPath}\"],
-            \"icon\": \"${itemIconURL}\"
+            \"paths\": [\"$(escapeJSONString "${itemValidationPath}")\"],
+            \"icon\": \"$(escapeJSONString "${itemIconURL}")\"
         }"
         elif [[ "${itemType}" == "jamf" ]]; then
             parseJamfPolicyItem "${itemConfig}"
             local jsonBlock="{
-            \"id\": \"${itemTrigger}\",
-            \"displayName\": \"${itemDisplayName}\",
+            \"id\": \"$(escapeJSONString "${itemTrigger}")\",
+            \"displayName\": \"$(escapeJSONString "${itemDisplayName}")\",
             \"guiIndex\": ${guiIndex},
-            \"paths\": [\"${itemValidationPath}\"],
-            \"icon\": \"${itemIconURL}\"
+            \"paths\": [\"$(escapeJSONString "${itemValidationPath}")\"],
+            \"icon\": \"$(escapeJSONString "${itemIconURL}")\"
+        }"
+        elif [[ "${itemType}" == "homebrew" ]]; then
+            parseHomebrewItem "${itemConfig}"
+            local jsonBlock="{
+            \"id\": \"$(escapeJSONString "${itemHomebrewID}")\",
+            \"displayName\": \"$(escapeJSONString "${itemDisplayName}")\",
+            \"guiIndex\": ${guiIndex},
+            \"paths\": [\"$(escapeJSONString "${itemValidationPath}")\"],
+            \"icon\": \"$(escapeJSONString "${itemIconURL}")\"
         }"
         else
             warning "Unknown item type for ID: ${itemID}"
@@ -1148,71 +1426,72 @@ function createSYMLiteInspectConfig() {
         ((guiIndex++))
     done
 
-    if [[ ${#selectedInstallomatorLabels[@]} -gt 0 && ${#selectedJamfPolicies[@]} -gt 0 ]]; then
-        dialogTitle="Processing ${totalItems} Item"
-        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}s"
-        messageText="Installing selected applications and executing policies. Items complete when files appear at their validation paths."
-        cachePathsJSON='        "/Library/Application Support/Installomator/Downloads",
-        "/Library/Application Support/JAMF/Downloads",
-        "/Library/Managed Installs/Cache"'
-        sideMessageJSON='        "Thank you for your patience.",
-        "Installation progress is monitored by watching for files to appear.",
-        "Applications are being installed via Installomator.",
-        "Policies are being executed via Jamf Pro.",
-        "Please wait while items are being processed.",
-        "Each item completes when its validation path appears.",
-        "This process may take several minutes.",
-        "The installation will complete automatically.",
-        "A restart may be required after completion."'
-    elif [[ ${#selectedJamfPolicies[@]} -gt 0 ]]; then
-        dialogTitle="Executing ${totalItems} Policy"
-        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}ies"
-        messageText="Executing selected policies. Items complete when files appear at their validation paths."
-        cachePathsJSON='        "/Library/Application Support/JAMF/Downloads",
-        "/Library/Managed Installs/Cache"'
-        sideMessageJSON='        "Thank you for your patience.",
-        "Progress is monitored by watching for files to appear.",
-        "Policies are being executed via Jamf Pro.",
-        "Please wait while items are being processed.",
-        "Each item completes when its validation path appears.",
-        "This process may take several minutes.",
-        "The installation will complete automatically.",
-        "A restart may be required after completion."'
-    else
-        dialogTitle="Installing ${totalItems} Application"
-        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}s"
-        messageText="Installing selected applications. Items complete when files appear at their validation paths."
-        cachePathsJSON='        "/Library/Application Support/Installomator/Downloads",
-        "/Library/Managed Installs/Cache"'
-        sideMessageJSON='        "Thank you for your patience.",
-        "Installation progress is monitored by watching for files to appear.",
-        "Applications are being installed via Installomator.",
-        "Please wait while items are being processed.",
-        "Each item completes when its validation path appears.",
-        "This process may take several minutes.",
-        "The installation will complete automatically.",
-        "A restart may be required after completion."'
-    fi
-    
-    # Create the full JSON configuration
-    # Note: Inspect Mode uses dual monitoring:
-    # - logMonitor: Parses Installomator.log for rich status updates (Installomator labels only)
-    # - paths: Watches file system via FSEvents for completion detection (both types)
-    if ! /bin/cat > "${dialogInspectModeJSONFile}" <<EOF
-{
-    "preset": "preset${organizationPreset}",
-    "title": "${dialogTitle}",
-    "message": "${messageText}",
-    "icon": "${mainDialogIcon}",
-    "overlayicon": "${organizationOverlayiconURL}",
-    "iconsize": 120,
-    "size": "compact",
-    "logMonitor": {
-        "path": "${installomatorLog}",
+    [[ ${#selectedInstallomatorLabels[@]} -gt 0 ]] && hasInstallomator="true"
+    [[ ${#selectedJamfPolicies[@]} -gt 0 ]] && hasJamf="true"
+    [[ ${#selectedHomebrewItems[@]} -gt 0 ]] && hasHomebrew="true"
+
+    cachePaths+=("/Library/Managed Installs/Cache")
+    sideMessages+=("Thank you for your patience.")
+    sideMessages+=("Progress is monitored by watching for files to appear.")
+    sideMessages+=("Please wait while items are being processed.")
+    sideMessages+=("Each item completes when its validation path appears.")
+    sideMessages+=("This process may take several minutes.")
+    sideMessages+=("The installation will complete automatically.")
+    sideMessages+=("A restart may be required after completion.")
+
+    if [[ "${hasInstallomator}" == "true" ]]; then
+        logMonitorJSON='    "logMonitor": {
+        "path": "'"$(escapeJSONString "${installomatorLog}")"'",
         "preset": "installomator",
         "autoMatch": true,
         "startFromEnd": true
-    },
+    },'
+        cachePaths+=("/Library/Application Support/Installomator/Downloads")
+        sideMessages+=("Applications are being installed via Installomator.")
+    fi
+
+    if [[ "${hasJamf}" == "true" ]]; then
+        cachePaths+=("/Library/Application Support/JAMF/Downloads")
+        sideMessages+=("Policies are being executed via Jamf Pro.")
+    fi
+
+    if [[ "${hasHomebrew}" == "true" ]]; then
+        [[ -n "${loggedInUserHomeDirectory}" ]] && cachePaths+=("${loggedInUserHomeDirectory}/Library/Caches/Homebrew")
+        cachePaths+=("/Library/Caches/Homebrew")
+        sideMessages+=("Approved Homebrew packages are being installed in the logged-in user context.")
+    fi
+
+    cachePathsJSON="$(buildJSONStringArray "${cachePaths[@]}")"
+    sideMessageJSON="$(buildJSONStringArray "${sideMessages[@]}")"
+
+    if [[ "${hasJamf}" == "true" && "${hasInstallomator}" != "true" && "${hasHomebrew}" != "true" ]]; then
+        dialogTitle="Executing ${totalItems} Policy"
+        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}ies"
+        messageText="Executing selected policies. Items complete when files appear at their validation paths."
+    elif [[ "${hasJamf}" == "true" ]]; then
+        dialogTitle="Processing ${totalItems} Item"
+        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}s"
+        messageText="Processing selected software and policies. Items complete when files appear at their validation paths."
+    else
+        dialogTitle="Installing ${totalItems} Item"
+        [[ ${totalItems} -gt 1 ]] && dialogTitle="${dialogTitle}s"
+        messageText="Installing selected software. Items complete when files appear at their validation paths."
+    fi
+    
+    # Create the full JSON configuration
+    # Note: Inspect Mode uses dual monitoring when Installomator items are selected:
+    # - logMonitor: Parses Installomator.log for rich status updates (Installomator labels only)
+    # - paths: Watches file system via FSEvents for completion detection (all item types)
+    if ! /bin/cat > "${dialogInspectModeJSONFile}" <<EOF
+{
+    "preset": "preset${organizationPreset}",
+    "title": "$(escapeJSONString "${dialogTitle}")",
+    "message": "$(escapeJSONString "${messageText}")",
+    "icon": "$(escapeJSONString "${mainDialogIcon}")",
+    "overlayicon": "$(escapeJSONString "${organizationOverlayiconURL}")",
+    "iconsize": 120,
+    "size": "compact",
+${logMonitorJSON}
     "cachePaths": [
 ${cachePathsJSON}
     ],
@@ -1325,6 +1604,10 @@ function parseOperationsCSV() {
                 warning "Skipping CSV item '${itemID}': Installomator label is unavailable in ${organizationInstallomatorFile}"
             elif [[ "${enableJamfPolicyItems:l}" != "true" ]] && isConfiguredJamfPolicyItem "${itemID}"; then
                 warning "Skipping CSV item '${itemID}': Jamf policy items are disabled"
+            elif [[ "${enableHomebrewItems:l}" != "true" ]] && isConfiguredHomebrewItem "${itemID}"; then
+                warning "Skipping CSV item '${itemID}': Homebrew items are disabled"
+            elif isConfiguredHomebrewItem "${itemID}"; then
+                warning "Skipping CSV item '${itemID}': Homebrew item is unavailable in this run"
             else
                 warning "Unknown item ID in CSV: '${itemID}'"
             fi
@@ -1369,10 +1652,10 @@ function parseDialogSelections() {
     local allIDs
     allIDs=($(getAllItemIDs))
 
-    # Primary: regex search for pattern like "itemID": true
+    # Primary: fixed-string search for pattern like "itemID": true
     local itemID
     for itemID in "${allIDs[@]}"; do
-        if echo "${output}" | grep -Eiq "${itemID}\"?[[:space:]]*:[[:space:]]*(true|1|yes)"; then
+        if echo "${output}" | grep -Fq "\"${itemID}\":true" || echo "${output}" | grep -Fq "\"${itemID}\": true"; then
             selectedItems+=("${itemID}")
         fi
     done
@@ -1380,7 +1663,7 @@ function parseDialogSelections() {
     # Fallback: JSON-aware jq parsing if grep found nothing
     if [[ ${#selectedItems[@]} -eq 0 ]] && command -v jq >/dev/null 2>&1; then
         for itemID in "${allIDs[@]}"; do
-            if echo "${output}" | jq -e ".${itemID} == true" >/dev/null 2>&1; then
+            if echo "${output}" | jq -e --arg key "${itemID}" '.[$key] == true' >/dev/null 2>&1; then
                 selectedItems+=("${itemID}")
             fi
         done
@@ -1403,7 +1686,7 @@ function showNoSelectableItemsDialog() {
     if [[ ${selectionDialogTotalItemCount} -gt 0 ]] \
     && [[ "${selectionDialogStatusSublabelsEnabled:l}" == "true" ]] \
     && [[ ${selectionDialogDisabledItemCount} -eq ${selectionDialogTotalItemCount} ]]; then
-        messageText="All configured items are already installed, so there is nothing new to install right now."
+        messageText="All configured items are already installed, so there is nothing new to process right now."
     fi
 
     runAsUser "${loggedInUser}" "${dialogBinary}" \
@@ -1444,7 +1727,7 @@ function showSelectionDialog() {
     local rc
 
     # Build message
-    baseMessage="**$(date +'Happy %A,') ${loggedInUserFirstname}!**\n\nSelect one or more applications to install."
+    baseMessage="**$(date +'Happy %A,') ${loggedInUserFirstname}!**\n\nSelect one or more approved items to process."
 
     # Build unified checkbox list (Installomator + Jamf, sorted together by display name)
     getSelectionDialogCheckboxesJSON
@@ -1475,7 +1758,7 @@ function showSelectionDialog() {
             --jsonstring "{\"checkbox\":${selectionDialogCheckboxesJSON}}" \
             --checkboxstyle "switch,large" \
             --json \
-            --button1text "Install" \
+            --button1text "Continue" \
             --button2text "Cancel" \
             --height 675 \
             --width 900 2>/dev/null)"
@@ -1494,7 +1777,7 @@ function showSelectionDialog() {
 
         # Warn and retry if no selections
         warning "No items selected in picker; re-showing selection dialog"
-        warningMessage="**:red[Warning:]** Please select at least _one_ option before clicking **Install**."
+        warningMessage="**:red[Warning:]** Please select at least _one_ option before clicking **Continue**."
     done
 }
 
@@ -1507,6 +1790,7 @@ function showSelectionDialog() {
 function separateSelectedItemsByType() {
     selectedInstallomatorLabels=()
     selectedJamfPolicies=()
+    selectedHomebrewItems=()
     
     for itemID in "${selectedItems[@]}"; do
         local itemType
@@ -1516,10 +1800,12 @@ function separateSelectedItemsByType() {
             selectedInstallomatorLabels+=("${itemID}")
         elif [[ "${itemType}" == "jamf" ]]; then
             selectedJamfPolicies+=("${itemID}")
+        elif [[ "${itemType}" == "homebrew" ]]; then
+            selectedHomebrewItems+=("${itemID}")
         fi
     done
     
-    info "Separated selections: ${#selectedInstallomatorLabels[@]} Installomator, ${#selectedJamfPolicies[@]} Jamf policies"
+    info "Separated selections: ${#selectedInstallomatorLabels[@]} Installomator, ${#selectedJamfPolicies[@]} Jamf policies, ${#selectedHomebrewItems[@]} Homebrew"
 }
 
 
@@ -1625,6 +1911,166 @@ function executeJamfPolicy() {
 
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Update Homebrew Metadata (Optional)
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function updateHomebrewMetadataIfNeeded() {
+    local homebrewUpdateExitCode=0
+    local homebrewCacheDirectory=""
+
+    if [[ "${homebrewUpdateBeforeInstall:l}" != "true" ]]; then
+        return 0
+    fi
+
+    if [[ "${homebrewUpdateAttempted}" == "true" ]]; then
+        [[ "${homebrewUpdateSucceeded}" == "true" ]] && return 0
+        return 1
+    fi
+
+    homebrewUpdateAttempted="true"
+
+    if ! refreshHomebrewExecutionUser; then
+        errorOut "No logged-in user is available to update Homebrew metadata"
+        homebrewUpdateSucceeded="false"
+        return 1
+    fi
+
+    homebrewCacheDirectory="$(getHomebrewCacheDirectory)"
+
+    notice "Updating Homebrew metadata as ${loggedInUser} …"
+    runAsUser "${loggedInUser}" /usr/bin/env \
+        HOME="${loggedInUserHomeDirectory}" \
+        USER="${loggedInUser}" \
+        LOGNAME="${loggedInUser}" \
+        XDG_CACHE_HOME="${loggedInUserHomeDirectory}/Library/Caches" \
+        HOMEBREW_CACHE="${homebrewCacheDirectory}" \
+        NONINTERACTIVE=1 \
+        HOMEBREW_NO_ENV_HINTS=1 \
+        "${effectiveBrewPath}" update 2>&1 | while IFS= read -r homebrewOutputLine; do
+        logComment "Homebrew (update): ${homebrewOutputLine}"
+    done
+    homebrewUpdateExitCode=${pipestatus[1]}
+
+    if [[ ${homebrewUpdateExitCode} -ne 0 ]]; then
+        errorOut "Homebrew update failed (exit code: ${homebrewUpdateExitCode})"
+        homebrewUpdateSucceeded="false"
+        return 1
+    fi
+
+    info "Homebrew metadata update completed"
+    homebrewUpdateSucceeded="true"
+    return 0
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+# Execute Homebrew Item
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
+
+function executeHomebrewItem() {
+    local homebrewID="$1"
+    local brewMode="$2"
+    local brewToken="$3"
+    local validationPath="$4"
+    local displayName="$5"
+    local iconURL="$6"
+    local homebrewExitCode=0
+    local homebrewCacheDirectory=""
+    local -a brewCommand=()
+
+    if [[ -n "${validationPath}" && -e "${validationPath}" ]]; then
+        info "Skipping Homebrew item '${homebrewID}': ${validationPath} already exists"
+        skippedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "alreadyInstalled" "success" "${iconURL}" "No action was needed" "Already installed"
+        return 0
+    fi
+
+    if [[ -z "${effectiveBrewPath}" || ! -x "${effectiveBrewPath}" ]]; then
+        errorOut "Homebrew item '${homebrewID}' cannot run because no working brew binary is available"
+        failedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "notInstalled" "fail" "${iconURL}" "Homebrew is not installed or not executable" "Not installed"
+        return 1
+    fi
+
+    if ! refreshHomebrewExecutionUser; then
+        errorOut "Homebrew item '${homebrewID}' cannot run because no logged-in user is available"
+        failedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "notInstalled" "fail" "${iconURL}" "A logged-in user is required for Homebrew installs" "Not installed"
+        return 1
+    fi
+
+    homebrewCacheDirectory="$(getHomebrewCacheDirectory)"
+
+    if ! updateHomebrewMetadataIfNeeded; then
+        failedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "notInstalled" "fail" "${iconURL}" "Homebrew metadata update failed" "Not installed"
+        return 1
+    fi
+
+    notice "Installing Homebrew ${brewMode} '${brewToken}' (${displayName}) as ${loggedInUser} …"
+
+    if [[ "${brewMode}" == "cask" ]]; then
+        brewCommand=(
+            /usr/bin/env
+            HOME="${loggedInUserHomeDirectory}"
+            USER="${loggedInUser}"
+            LOGNAME="${loggedInUser}"
+            XDG_CACHE_HOME="${loggedInUserHomeDirectory}/Library/Caches"
+            HOMEBREW_CACHE="${homebrewCacheDirectory}"
+            NONINTERACTIVE=1
+            HOMEBREW_NO_AUTO_UPDATE=1
+            HOMEBREW_NO_ENV_HINTS=1
+            "${effectiveBrewPath}"
+            install
+            --cask
+            "${brewToken}"
+        )
+    else
+        brewCommand=(
+            /usr/bin/env
+            HOME="${loggedInUserHomeDirectory}"
+            USER="${loggedInUser}"
+            LOGNAME="${loggedInUser}"
+            XDG_CACHE_HOME="${loggedInUserHomeDirectory}/Library/Caches"
+            HOMEBREW_CACHE="${homebrewCacheDirectory}"
+            NONINTERACTIVE=1
+            HOMEBREW_NO_AUTO_UPDATE=1
+            HOMEBREW_NO_ENV_HINTS=1
+            "${effectiveBrewPath}"
+            install
+            "${brewToken}"
+        )
+    fi
+
+    runAsUser "${loggedInUser}" "${brewCommand[@]}" 2>&1 | while IFS= read -r homebrewOutputLine; do
+        logComment "Homebrew (${homebrewID}): ${homebrewOutputLine}"
+    done
+    homebrewExitCode=${pipestatus[1]}
+
+    if [[ ${homebrewExitCode} -ne 0 ]]; then
+        errorOut "Homebrew install failed for '${homebrewID}' (exit code: ${homebrewExitCode})"
+        failedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "notInstalled" "fail" "${iconURL}" "Please contact support if this package is required" "Not installed"
+        return 1
+    fi
+
+    if [[ -n "${validationPath}" && -e "${validationPath}" ]]; then
+        info "Homebrew install completed for '${homebrewID}' and validated"
+        completedItems+=("${displayName}")
+        addCompletionReportRecord "${displayName}" "installed" "success" "${iconURL}" "Ready to use" "Installed"
+        return 0
+    fi
+
+    warning "Homebrew install '${homebrewID}' completed but validation path not found: ${validationPath}"
+    completedItems+=("${displayName}")
+    addCompletionReportRecord "${displayName}" "needsReview" "error" "${iconURL}" "Installed, but we could not fully confirm the result" "Needs review"
+    return 0
+}
+
+
+
+# # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 # Unified Execution Dispatcher
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
@@ -1674,6 +2120,9 @@ function executeSYMLiteItems() {
         elif [[ "${itemType}" == "jamf" ]]; then
             parseJamfPolicyItem "${itemConfig}"
             executeJamfPolicy "${itemTrigger}" "${itemValidationPath}" "${itemDisplayName}" "${itemIconURL}"
+        elif [[ "${itemType}" == "homebrew" ]]; then
+            parseHomebrewItem "${itemConfig}"
+            executeHomebrewItem "${itemHomebrewID}" "${itemBrewMode}" "${itemBrewToken}" "${itemValidationPath}" "${itemDisplayName}" "${itemIconURL}"
         else
             warning "Unknown item type for ID: ${itemID}"
         fi
@@ -1752,7 +2201,7 @@ function showCompletionDialog() {
     local statusText=""
     local dialogTitle=""
     local dialogIcon=""
-    local dialogMessage="Here's the status of your selected software, ${loggedInUserFirstname}.\n\n"
+    local dialogMessage="Here's the status of your selected items, ${loggedInUserFirstname}.\n\n"
     local listItemsJSON=""
     local completionDialogJSON=""
     local jsonValidationError=""
@@ -1785,7 +2234,7 @@ function showCompletionDialog() {
         dialogTitle="Completed with Warnings"
         dialogIcon="SF=exclamationmark.triangle.fill,weight=bold,colour1=#F8D84A,colour2=#D18E00"
     else
-        dialogTitle="Installation Complete"
+        dialogTitle="Processing Complete"
         dialogIcon="SF=checkmark.circle.fill,weight=bold,colour1=#63CA56,colour2=#2D7D2B"
     fi
 
@@ -1897,7 +2346,7 @@ function promptForRestart() {
         --title "Restart Recommended" \
         --infotext "${scriptVersion}" \
         --messagefont "size=${restartFontSize}" \
-        --message "**A restart is recommended after performing any installation.**\n\nWould you like to restart now?" \
+        --message "**A restart may be recommended after installing software or applying these changes.**\n\nWould you like to restart now?" \
         --icon "SF=restart.circle.fill,colour=#969899" \
         --buttonstyle "stack" \
         --button1text "Restart Now" \
@@ -1924,9 +2373,12 @@ function promptForRestart() {
 ####################################################################################################
 
 notice "SYM-Lite initialized successfully"
-notice "Configuration: ${#installomatorLabels[@]} Installomator labels, ${#jamfPolicyItems[@]} Jamf policy items"
+notice "Configuration: ${#installomatorLabels[@]} Installomator labels, ${#jamfPolicyItems[@]} Jamf policy items, ${#homebrewItems[@]} Homebrew items"
 if [[ "${enableJamfPolicyItems:l}" != "true" ]]; then
     notice "Jamf policy items are disabled by configuration"
+fi
+if [[ "${enableHomebrewItems:l}" != "true" ]]; then
+    notice "Homebrew items are disabled by configuration"
 fi
 notice "Operation mode: ${operationMode}"
 


### PR DESCRIPTION
## 08-Apr-2026
- Added approved Homebrew cask/formula items as a third item type in the unified picker and silent-mode CSV flow.
- Added Homebrew binary detection, configuration toggles, and invalid-item filtering during pre-flight.
- Added user-context Homebrew execution with optional one-time `brew update` support.
- Expanded Inspect Mode, completion reporting, and user-facing copy to support Homebrew items alongside Installomator labels and Jamf policies.
- Updated project documentation and repo instructions for Homebrew item support.

<img width="1012" height="819" alt="Screenshot 2026-04-08 at 2 58 48 PM" src="https://github.com/user-attachments/assets/8b934f5f-7b4c-4ebf-82ff-7d2430336fa3" />
